### PR TITLE
[Thirdperson] Copy reference camera settings & DesktopVRSwitch support.

### DIFF
--- a/ThirdPerson/CameraLogic.cs
+++ b/ThirdPerson/CameraLogic.cs
@@ -46,7 +46,6 @@ internal static class CameraLogic
         yield return new WaitUntil(() => PlayerSetup.Instance && PlayerSetup.Instance.GetActiveCamera());
         _ourCam = new GameObject { gameObject = { name = "ThirdPersonCameraObj" } };
         _ourCam.AddComponent<Camera>();
-        //_ourCam.AddComponent<WorldTransitionCamera>();
         ParentCameraObject();
         ThirdPerson.Logger.Msg("Finished setting up third person camera.");
     }

--- a/ThirdPerson/CameraLogic.cs
+++ b/ThirdPerson/CameraLogic.cs
@@ -1,14 +1,19 @@
-﻿using System.Collections;
-using ABI_RC.Core;
+﻿using ABI_RC.Core.Base;
+using ABI_RC.Core.Player;
+using Aura2API;
+using BeautifyEffect;
+using System.Collections;
+using System.Reflection;
 using UnityEngine;
-using static ThirdPerson.ThirdPerson;
+using UnityEngine.AzureSky;
+using UnityEngine.Rendering.PostProcessing;
 
 namespace ThirdPerson;
 
 internal static class CameraLogic
 {
     private static float _dist;
-    private static GameObject _ourCam, _defaultCam;
+    internal static GameObject _ourCam, _defaultCam;
     internal static CameraLocation CurrentLocation = CameraLocation.Default;
     internal enum CameraLocation
     {
@@ -17,34 +22,124 @@ internal static class CameraLogic
         RightSide,
         LeftSide
     }
-    
+
     private static bool _state;
     internal static bool PreviousState;
-    internal static bool State {
+    internal static bool State
+    {
         get => _state;
-        set {
+        set
+        {
             PreviousState = _state;
             _state = value;
             _ourCam.SetActive(_state);
-        } 
+        }
     }
+
+    private static readonly FieldInfo ppResources = typeof(PostProcessLayer).GetField("m_Resources", BindingFlags.NonPublic | BindingFlags.Instance);
+    private static readonly FieldInfo ppOldResources = typeof(PostProcessLayer).GetField("m_OldResources", BindingFlags.NonPublic | BindingFlags.Instance);
 
     internal static IEnumerator SetupCamera()
     {
-        yield return new WaitUntil(() => RootLogic.Instance && RootLogic.Instance.activeCamera);
-        _defaultCam = RootLogic.Instance.activeCamera.gameObject;
+        yield return new WaitUntil(() => PlayerSetup.Instance && PlayerSetup.Instance.GetActiveCamera());
         _ourCam = new GameObject { gameObject = { name = "ThirdPersonCameraObj" } };
+        _ourCam.AddComponent<Camera>();
+        ParentCamObj();
+        ThirdPerson.Logger.Msg("Finished setting up third person camera.");
+    }
+
+    internal static void ParentCamObj()
+    {
+        _defaultCam = PlayerSetup.Instance.GetActiveCamera();
         _ourCam.transform.SetParent(_defaultCam.transform);
         RelocateCam(CameraLocation.Default);
         _ourCam.gameObject.SetActive(false);
-        _ourCam.AddComponent<Camera>();
-        ThirdPerson.Logger.Msg("Finished setting up third person camera.");
+        ThirdPerson.Logger.Msg("Parenting ThirdPerson camera object to active camera.");
+    }
+
+    internal static void CopyFromPlayerCam()
+    {
+        Camera ourCamComponent = _ourCam.GetComponent<Camera>();
+        Camera playerCamComponent = _defaultCam.GetComponent<Camera>();
+        if (ourCamComponent == null || playerCamComponent == null) return;
+        ThirdPerson.Logger.Msg("Copying active camera settings & components.");
+
+        //steal basic settings
+        ourCamComponent.farClipPlane = playerCamComponent.farClipPlane;
+        ourCamComponent.nearClipPlane = playerCamComponent.nearClipPlane;
+        ourCamComponent.cullingMask = playerCamComponent.cullingMask;
+        ourCamComponent.depthTextureMode = playerCamComponent.depthTextureMode;
+
+        //steal post processing if added
+        PostProcessLayer ppLayerPlayerCam = playerCamComponent.GetComponent<PostProcessLayer>();
+        PostProcessLayer ppLayerThirdPerson = ourCamComponent.AddComponentIfMissing<PostProcessLayer>();
+        if (ppLayerPlayerCam != null && ppLayerThirdPerson != null)
+        {
+            ppLayerThirdPerson.enabled = ppLayerPlayerCam.enabled;
+            ppLayerThirdPerson.volumeLayer = ppLayerPlayerCam.volumeLayer;
+            //need to copy these via reflection, otherwise post processing will error
+            //we only need to copy these once on first setup, but eh it works
+            PostProcessResources resources = (PostProcessResources)ppResources.GetValue(ppLayerPlayerCam);
+            PostProcessResources oldResources = (PostProcessResources)ppOldResources.GetValue(ppLayerPlayerCam);
+            ppResources.SetValue(ppLayerThirdPerson, resources);
+            ppResources.SetValue(ppLayerThirdPerson, oldResources);
+        }
+
+        //what even is this aura camera stuff
+        AuraCamera auraPlayerCam = playerCamComponent.GetComponent<AuraCamera>();
+        AuraCamera auraThirdPerson = ourCamComponent.AddComponentIfMissing<AuraCamera>();
+        if (auraPlayerCam != null && auraThirdPerson != null)
+        {
+            auraThirdPerson.enabled = auraPlayerCam.enabled;
+            auraThirdPerson.frustumSettings = auraPlayerCam.frustumSettings;
+        }
+        else
+        {
+            auraThirdPerson.enabled = false;
+        }
+
+        //flare layer thing? the sun :_:_:_:_:_:
+        FlareLayer flarePlayerCam = playerCamComponent.GetComponent<FlareLayer>();
+        FlareLayer flareThirdPerson = ourCamComponent.AddComponentIfMissing<FlareLayer>();
+        if (flarePlayerCam != null && flareThirdPerson != null)
+        {
+            flareThirdPerson.enabled = flarePlayerCam.enabled;
+        }
+        else
+        {
+            flareThirdPerson.enabled = false;
+        }
+
+        //and now what the fuck is fog scattering
+        AzureFogScattering azureFogPlayerCam = playerCamComponent.GetComponent<AzureFogScattering>();
+        AzureFogScattering azureFogThirdPerson = ourCamComponent.AddComponentIfMissing<AzureFogScattering>();
+        if (azureFogPlayerCam != null && azureFogThirdPerson != null)
+        {
+            azureFogThirdPerson.fogScatteringMaterial = azureFogPlayerCam.fogScatteringMaterial;
+        }
+        else
+        {
+            Object.Destroy(ourCamComponent.GetComponent<AzureFogScattering>());
+        }
+
+        //why is there so many thingsssssssss
+        Beautify beautifyPlayerCam = playerCamComponent.GetComponent<Beautify>();
+        Beautify beautifyThirdPerson = ourCamComponent.AddComponentIfMissing<Beautify>();
+        if (beautifyPlayerCam != null && beautifyThirdPerson != null)
+        {
+            beautifyThirdPerson.quality = beautifyPlayerCam.quality;
+            beautifyThirdPerson.profile = beautifyPlayerCam.profile;
+        }
+        else
+        {
+            Object.Destroy(ourCamComponent.gameObject.GetComponent<Beautify>());
+        }
     }
 
     internal static void RelocateCam(CameraLocation location, bool resetDist = false)
     {
         _ourCam.transform.rotation = _defaultCam.transform.rotation;
-        if(resetDist) ResetDist();
+        if (resetDist) ResetDist();
         switch (location)
         {
             case CameraLocation.FrontView:
@@ -53,7 +148,7 @@ internal static class CameraLogic
                 CurrentLocation = CameraLocation.FrontView;
                 break;
             case CameraLocation.RightSide:
-                _ourCam.transform.localPosition =  new Vector3(0.3f, 0.015f, -0.55f + _dist);
+                _ourCam.transform.localPosition = new Vector3(0.3f, 0.015f, -0.55f + _dist);
                 _ourCam.transform.localRotation = new Quaternion(0, 0, 0, 0);
                 CurrentLocation = CameraLocation.RightSide;
                 break;
@@ -70,7 +165,7 @@ internal static class CameraLogic
                 break;
         }
     }
-    
+
     private static void ResetDist() => _dist = 0;
     internal static void IncrementDist() { _dist += 0.25f; RelocateCam(CurrentLocation); }
     internal static void DecrementDist() { _dist -= 0.25f; RelocateCam(CurrentLocation); }

--- a/ThirdPerson/Patches.cs
+++ b/ThirdPerson/Patches.cs
@@ -22,12 +22,10 @@ internal static class Patches
         );
         harmony.Patch(
             typeof(CVRWorld).GetMethod("SetDefaultCamValues", BindingFlags.NonPublic | BindingFlags.Instance),
-            null,
             postfix: typeof(Patches).GetMethod(nameof(OnWorldStart), BindingFlags.NonPublic | BindingFlags.Static).ToNewHarmonyMethod()
          );
         harmony.Patch(
             typeof(CVRWorld).GetMethod("CopyRefCamValues", BindingFlags.NonPublic | BindingFlags.Instance),
-            null,
             postfix: typeof(Patches).GetMethod(nameof(OnWorldStart), BindingFlags.NonPublic | BindingFlags.Static).ToNewHarmonyMethod()
          );
     }
@@ -52,12 +50,7 @@ internal static class Patches
         };
     }
     //DesktopVRSwitch Support
-    private static void OnCalibrateAvatar()
-    {
-        if (_defaultCam != null && _defaultCam != PlayerSetup.Instance.GetActiveCamera())
-        {
-            ParentCamObj();
-        }
-    }
+    private static void OnCalibrateAvatar() => CheckVRSwitch();
+    //Copy camera settings & postprocessing components
     private static void OnWorldStart() => CopyFromPlayerCam();
 }

--- a/ThirdPerson/Patches.cs
+++ b/ThirdPerson/Patches.cs
@@ -21,6 +21,10 @@ internal static class Patches
             prefix: typeof(Patches).GetMethod(nameof(ToggleQuickMenu), BindingFlags.NonPublic | BindingFlags.Static).ToNewHarmonyMethod()
         );
         harmony.Patch(
+            typeof(PlayerSetup).GetMethod(nameof(PlayerSetup.CalibrateAvatar), BindingFlags.Public | BindingFlags.Instance),
+            postfix: typeof(Patches).GetMethod(nameof(OnCalibrateAvatar), BindingFlags.NonPublic | BindingFlags.Static).ToNewHarmonyMethod()
+         );
+        harmony.Patch(
             typeof(CVRWorld).GetMethod("SetDefaultCamValues", BindingFlags.NonPublic | BindingFlags.Instance),
             postfix: typeof(Patches).GetMethod(nameof(OnWorldStart), BindingFlags.NonPublic | BindingFlags.Static).ToNewHarmonyMethod()
          );

--- a/ThirdPerson/ThirdPerson.cs
+++ b/ThirdPerson/ThirdPerson.cs
@@ -1,9 +1,9 @@
-﻿using System;
+﻿using MelonLoader;
+using System;
 using System.Reflection;
-using MelonLoader;
 using UnityEngine;
-using BuildInfo = ThirdPerson.BuildInfo;
 using static ThirdPerson.CameraLogic;
+using BuildInfo = ThirdPerson.BuildInfo;
 
 [assembly: AssemblyCopyright("Created by " + BuildInfo.Author)]
 [assembly: MelonInfo(typeof(ThirdPerson.ThirdPerson), BuildInfo.Name, BuildInfo.Version, BuildInfo.Author)]
@@ -22,19 +22,19 @@ public static class BuildInfo
 public class ThirdPerson : MelonMod
 {
     internal static MelonLogger.Instance Logger;
-    
-    public override void OnApplicationStart() 
+
+    public override void OnInitializeMelon()
     {
         Logger = LoggerInstance;
-        
+
         MelonCoroutines.Start(SetupCamera());
-        
+
         Patches.Apply(HarmonyInstance);
     }
-    
+
     public override void OnUpdate()
     {
-        if(State)
+        if (State)
         {
             if (Input.GetAxis("Mouse ScrollWheel") > 0f) IncrementDist();
             else if (Input.GetAxis("Mouse ScrollWheel") < 0f) DecrementDist();


### PR DESCRIPTION
Copy player camera settings & components on world load. Check for VR mode changes on avatar switch.

Also updated from OnApplicationStart to OnInitializeMelon.